### PR TITLE
Remove unique index from UserData

### DIFF
--- a/cmd/cdn-broker/main.go
+++ b/cmd/cdn-broker/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	session := session.New(aws.NewConfig().WithRegion(settings.AwsDefaultRegion))
 
-	if err := db.AutoMigrate(&models.Route{}, &models.Certificate{}, &models.UserData{}).Error; err != nil {
+	if err := models.Migrate(db); err != nil {
 		logger.Fatal("migrate", err)
 	}
 

--- a/models/models.go
+++ b/models/models.go
@@ -112,6 +112,14 @@ func LoadUser(userData UserData) (utils.User, error) {
 	return user, nil
 }
 
+func Migrate(db *gorm.DB) error {
+	if err := db.AutoMigrate(&Route{}, &Certificate{}, &UserData{}).Error; err != nil {
+		return err
+	}
+	db.Model(&UserData{}).RemoveIndex("uix_user_data_email")
+	return nil
+}
+
 // loadPrivateKey loads a PEM-encoded ECC/RSA private key from an array of bytes.
 func loadPrivateKey(keyBytes []byte) (crypto.PrivateKey, error) {
 	keyBlock, _ := pem.Decode(keyBytes)


### PR DESCRIPTION
We (alphagov) recently tried to [merge master into our fork](https://github.com/alphagov/paas-cdn-broker/pull/8). When we tried to deploy the broker, it wouldn't start due to a unique constraint violation. We found that a UserData index was dropped in df3131d512ebcd501837f4f8a7e0f866d7171d57, but it didn't get an associated migration. Gorm's AutoMigrate will [apparently not remove indices](http://jinzhu.me/gorm/database.html#migration).

This PR is mostly about asking you folks whether you'd prefer:

- not doing this at all (since you figured out how to deploy, presumably by manually removing the index)
- doing the migration this way, which is a little hacky, but works for this one case where we're removing an index
- doing the migration another way, perhaps with explicit [gormigrate](https://github.com/go-gormigrate/gormigrate) migrations
  