### PR TITLE
Set origin keep-alive timeout to default

### DIFF
--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -132,10 +132,11 @@ func (d *Distribution) fillDistributionConfig(config *cloudfront.DistributionCon
 					Quantity: aws.Int64(0),
 				},
 				CustomOriginConfig: &cloudfront.CustomOriginConfig{
-					HTTPPort:             aws.Int64(80),
-					HTTPSPort:            aws.Int64(443),
-					OriginReadTimeout:    aws.Int64(30),
-					OriginProtocolPolicy: getOriginProtocolPolicy(insecureOrigin),
+					HTTPPort:               aws.Int64(80),
+					HTTPSPort:              aws.Int64(443),
+					OriginReadTimeout:      aws.Int64(30),
+					OriginKeepaliveTimeout: aws.Int64(5),
+					OriginProtocolPolicy:   getOriginProtocolPolicy(insecureOrigin),
 					OriginSslProtocols: &cloudfront.OriginSslProtocols{
 						Quantity: aws.Int64(3),
 						Items: []*string{


### PR DESCRIPTION
CloudFront now requires setting origin keep-alive timeout on updates.

😐 