### PR TITLE
remove log of sensitive data

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -450,7 +450,6 @@ func (m *RouteManager) stillActive(r *Route) error {
 
 	lsession.Info("starting-canary-check", lager.Data{
 		"route":       r,
-		"settings":    m.settings,
 		"instance-id": r.InstanceId,
 	})
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- the `Settings` struct contains AWS key information: https://github.com/cloud-gov/cf-cdn-service-broker/blob/42e47a9371fd070b37f3d6575bd87d92b473f1f5/config/config.go#L20-L22, so removing the line that it includes it in logs

## security considerations

This change removes code that was logging sensitive information to the output
