### PR TITLE
Fix error handling

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -151,7 +151,7 @@ func (b *CdnServiceBroker) LastOperation(
 		}, nil
 	case models.Failed:
 		return brokerapi.LastOperation{
-			State: brokerapi.Failed,
+			State:       brokerapi.Failed,
 			Description: "Failure while provisioning instance",
 		}, nil
 	default:
@@ -182,7 +182,7 @@ func (b *CdnServiceBroker) Deprovision(
 
 	err = b.manager.Disable(route)
 	if err != nil {
-		return brokerapi.DeprovisionServiceSpec{}, nil
+		return brokerapi.DeprovisionServiceSpec{}, err
 	}
 
 	return brokerapi.DeprovisionServiceSpec{IsAsync: true}, nil

--- a/broker/broker_deprovision_test.go
+++ b/broker/broker_deprovision_test.go
@@ -1,0 +1,77 @@
+package broker_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/pivotal-cf/brokerapi"
+
+	"github.com/cloud-gov/cf-cdn-service-broker/broker"
+	cfmock "github.com/cloud-gov/cf-cdn-service-broker/cf/mocks"
+	"github.com/cloud-gov/cf-cdn-service-broker/config"
+	"github.com/cloud-gov/cf-cdn-service-broker/models"
+	"github.com/cloud-gov/cf-cdn-service-broker/models/mocks"
+)
+
+func TestDeprovisioning(t *testing.T) {
+	suite.Run(t, new(DeprovisionSuite))
+}
+
+type DeprovisionSuite struct {
+	suite.Suite
+	Manager  mocks.RouteManagerIface
+	Broker   *broker.CdnServiceBroker
+	cfclient cfmock.Client
+	settings config.Settings
+	logger   lager.Logger
+	ctx      context.Context
+}
+
+func (s *DeprovisionSuite) SetupTest() {
+	s.Manager = mocks.RouteManagerIface{}
+	s.cfclient = cfmock.Client{}
+	s.logger = lager.NewLogger("broker.provision.test")
+	s.settings = config.Settings{
+		DefaultOrigin: "origin.cloud.gov",
+	}
+	s.Broker = broker.New(
+		&s.Manager,
+		&s.cfclient,
+		s.settings,
+		s.logger,
+	)
+	s.ctx = context.Background()
+}
+
+func (s *DeprovisionSuite) TestDeprovisionSuccess() {
+	details := brokerapi.DeprovisionDetails{}
+
+	route := &models.Route{
+		State: models.Provisioned,
+	}
+	s.Manager.On("Get", "123").Return(route, nil)
+
+	s.Manager.On("Disable", route).Return(nil)
+
+	_, err := s.Broker.Deprovision(s.ctx, "123", details, true)
+	s.Nil(err)
+}
+
+func (s *DeprovisionSuite) TestDeprovisioDisableError() {
+	details := brokerapi.DeprovisionDetails{}
+
+	route := &models.Route{
+		State: models.Provisioned,
+	}
+	s.Manager.On("Get", "123").Return(route, nil)
+
+	s.Manager.On("Disable", route).Return(errors.New("failed disabling"))
+
+	_, err := s.Broker.Deprovision(s.ctx, "123", details, true)
+	s.NotNil(err)
+	s.Contains(err.Error(), "failed disabling")
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- [fix error handling on deprovision to return error when disabling CDN service](https://github.com/cloud-gov/cf-cdn-service-broker/commit/60dcf01d0340f04e0ae65907e939f77ad878b9db)
- [add tests for broker deprovision operations](https://github.com/cloud-gov/cf-cdn-service-broker/commit/f55ccdd6527c2aaae26ffa7e57cc5eb2a7038495)

## security considerations

None, just fixing broken deprovision logic
